### PR TITLE
feat: Implement backend calls to AddMedication and Home

### DIFF
--- a/src/components/common/MedicationItem.tsx
+++ b/src/components/common/MedicationItem.tsx
@@ -4,7 +4,10 @@ import { Check, Edit, Trash } from "lucide-react";
 
 export interface Medication {
     id: string;
+    comercialNameId?: number;
+    presentationId?: number;
     name: string;
+    hourSchedule?: number;
     dosageStrength?: string;
     adultDosage?: string;
     pediatric_dosage?: string;

--- a/src/components/home/MedicationTimeGroup.tsx
+++ b/src/components/home/MedicationTimeGroup.tsx
@@ -1,10 +1,10 @@
-import type { MedicationTime } from "@/data/medicationTimeListFake.ts";
 import MedicationItem from "@/components/common/MedicationItem.tsx";
+import type { MedicationByTime } from "@/routes/Home/SchuduleMapper.tsx";
 
-export function MedicationTimeGroup({time, medications}: MedicationTime) {
+export function MedicationTimeGroup({time, medications}: MedicationByTime) {
     return (
-        <div className={"mb-16 w-full"}>
-            <div className="text-black text-xl font-semibold mb-8 columns-1">{time}</div>
+        <div className={"mb-8 w-full"}>
+            <div className="text-black text-xl font-semibold mb-4 columns-1">{time}</div>
             {medications.map((med, index) => (
                 <MedicationItem key={index} {...med} />
             ))}

--- a/src/data/common/HttpExtensions.ts
+++ b/src/data/common/HttpExtensions.ts
@@ -12,3 +12,27 @@ export async function getRequest(url: string) {
         return json
     })
 }
+
+export async function postRequest(url: string, { arg }: { arg: any }) {  // Change the signature to match SWR's format
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(arg)  // Use arg directly, as SWR wraps the data
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => null);
+            throw new Error(`Request failed with status ${response.status}: ${
+                errorData ? JSON.stringify(errorData) : 'No error details'
+            }`);
+        }
+
+        return response.json();
+    } catch (error) {
+        console.error('POST request failed:', error);
+        throw error;
+    }
+}

--- a/src/data/common/Mapper.ts
+++ b/src/data/common/Mapper.ts
@@ -1,7 +1,7 @@
 import type { Medication } from "@/components/common/MedicationItem.tsx";
 
 export interface Drug {
-    code: string
+    id: number
     comercial_name: string
     active_ingredients: ActiveIngredient[]
     presentations: Presentation[],
@@ -13,7 +13,7 @@ interface ActiveIngredient {
     active_ingredient: string
 }
 
-interface Presentation {
+export interface Presentation {
     id: number
     value: string
 }
@@ -21,7 +21,9 @@ interface Presentation {
 export function mapDrugsToMedications(data: Drug[] | undefined): Medication[] {
     return data?.flatMap((drug) =>
         drug.presentations.map((presentation) => ({
-            id: `${drug.code}-${presentation.id}`,
+            id: `${drug.id}-${presentation.id}`,
+            comercialNameId: drug.id,
+            presentationId: presentation.id,
             name: drug.comercial_name,
             dosageStrength: presentation.value,
         }))
@@ -43,9 +45,11 @@ export interface UserDrug {
 }
 
 export function mapUserDrugToMedications(data: UserDrug[] | undefined): Medication[] {
-    return data?.map((item) => ({
-        id: item.id.toString(),
-        name: item.comercial_name.comercial_name,
-        dosageStrength: item.presentation.value
-    })) || [];
+    return Array.isArray(data)
+        ? data.flatMap((item) => ({
+            id: item.id.toString(),
+            name: item.comercial_name.comercial_name,
+            dosageStrength: item.presentation.value,
+        }))
+        : [];
 }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,7 +1,27 @@
-import { medicationsList } from "@/data/medicationTimeListFake.ts";
 import { MedicationTimeGroup } from "@/components/home/MedicationTimeGroup.tsx";
+import useSWRMutation from "swr/mutation";
+import { getRequest } from "@/data/common/HttpExtensions.ts";
+import { useEffect, useState } from "react";
+import type { ScheduleResponse } from "@/routes/Home/SchuduleMapper.tsx";
+import { getMedicationsByWeekday } from "@/routes/Home/SchuduleMapper.tsx";
 
 export default function Home() {
+    const [currentDate, setCurrentDate] = useState('');
+
+    const {data, trigger} = useSWRMutation<ScheduleResponse[]>('http://localhost:8000/schedule/1/schedule', getRequest);
+    useEffect(() => {
+        const today = new Date();
+        const options: Intl.DateTimeFormatOptions = { weekday: 'short', day: 'numeric', month: 'long' };
+        let formattedDate = today.toLocaleDateString('pt-BR', options);
+        formattedDate = formattedDate.replace('.', '').replace(/^./, (str) => str.toUpperCase());
+        setCurrentDate(formattedDate);
+
+        trigger();
+    }, [trigger]);
+
+    const medications = getMedicationsByWeekday(data);
+    console.log(medications);
+
     const handleCheck = (isChecked: Boolean, id: string) => {
         if (isChecked) {
             console.log(`Checked item with id: ${id}`);
@@ -15,12 +35,11 @@ export default function Home() {
             <div className="flex w-full justify-center">
                 <div className="text-black text-2xl font-semibold leading-loose">Medicamentos do dia</div>
             </div>
-            <div className="mt-12 text-black text-base font-normal leading-normal">Sex, 13 de Setembro</div>
+            <div className="mt-12 text-black text-base font-normal leading-normal">{currentDate}</div>
             <div className="flex-1 max-h-screen w-full overflow-y-auto mt-4 pb-6">
-                {medicationsList.map((item, index) => (
+                {medications.map((item, index) => (
                     <MedicationTimeGroup
                         key={index}
-                        id={item.id}
                         time={item.time}
                         medications={item.medications.map((medication) => ({
                             ...medication,

--- a/src/routes/Home/SchuduleMapper.tsx
+++ b/src/routes/Home/SchuduleMapper.tsx
@@ -1,0 +1,72 @@
+import { getDay } from 'date-fns';
+import type { Presentation } from "@/data/common/Mapper.ts";
+import type { Medication } from "@/components/common/MedicationItem.tsx";
+
+interface DrugUse {
+    id: number;
+    start_date: string;
+    end_date: string;
+    observation: string;
+    quantity: number;
+    comercial_name: ComercialName;
+    presentation: Presentation;
+    status: string;
+}
+
+interface ComercialName {
+    id: number;
+    comercial_name: string;
+}
+
+interface Schedule {
+    id: number;
+    type: string;
+    drug_use_id: number;
+    value: number;
+}
+
+export interface ScheduleResponse {
+    drug_use: DrugUse;
+    schedules: Schedule[];
+}
+
+export interface MedicationByTime {
+    time: number;
+    medications: Medication[];
+}
+
+export function getMedicationsByWeekday(schedules: ScheduleResponse[] = []): MedicationByTime[] {
+    const today = getDay(new Date());
+
+    const medicationsByTime: MedicationByTime[] = [];
+
+    schedules.forEach((schedule) => {
+        const dailySchedules = schedule.schedules.filter((s) => s.type === 'D' && s.value === today);
+        dailySchedules.forEach((dailySchedule) => {
+            const hourlySchedules = schedule.schedules.filter((s) => s.type === 'H' && s.drug_use_id === dailySchedule.drug_use_id);
+            hourlySchedules.forEach((hourlySchedule) => {
+                const medication: Medication = {
+                    id: hourlySchedule.id.toString(),
+                    comercialNameId: schedule.drug_use.comercial_name.id,
+                    presentationId: schedule.drug_use.presentation.id,
+                    name: schedule.drug_use.comercial_name.comercial_name,
+                    dosageStrength: schedule.drug_use.presentation.value,
+                    hourSchedule: hourlySchedule.value,
+                };
+
+                const existingMedicationIndex = medicationsByTime.findIndex((item) => item.time === hourlySchedule.value);
+                if (medicationsByTime[existingMedicationIndex]) {
+                    medicationsByTime[existingMedicationIndex].medications.push(medication);
+                } else {
+                    medicationsByTime.push({
+                        time: hourlySchedule.value,
+                        medications: [medication],
+                    });
+                }
+            });
+        });
+    });
+
+    return medicationsByTime.sort((a, b) => a.time - b.time);
+
+}

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -10,7 +10,7 @@ import { getRequest } from "@/data/common/HttpExtensions.ts";
 
 
 export default function Profile() {
-    const {data, trigger} = useSWRMutation<UserDrug[]>('http://localhost:8000/user_drugs/2', getRequest);
+    const {data, trigger} = useSWRMutation<UserDrug[]>('http://localhost:8000/drugs/1/', getRequest);
 
     useEffect(() => {
         trigger();


### PR DESCRIPTION
Add `POST /drugs/{user_id}` and `POST /schedule/{user_id}/schedule` to AddMedication screes, enabling users to add a medication.

Add `GET /schedule/{user_id}/schedule` to the Home screen, enabling users to see what medication they need to take today.

Add `GET /drugs/{user_id}` to the Profile screen, enabling users to see what medication they have registered.