### PR TITLE
feat: add WeekDaySelector component with toggle and readonly support …

### DIFF
--- a/src/view/components/common/WeekDaySelector.tsx
+++ b/src/view/components/common/WeekDaySelector.tsx
@@ -1,0 +1,38 @@
+
+
+
+interface WeekDaySelectorProps {
+   values: number[];
+   isReadOnly: boolean;
+   onChange?: (days: number[]) => void;
+}
+
+export function WeekDaySelector({ values, isReadOnly, onChange }: WeekDaySelectorProps) {
+
+   const days = ['D', 'S', 'T', 'Q', 'Q', 'S', 'S'];
+
+   function handleToggle(index: number) {
+      console.log(index)
+      console.log(values)
+      if (values.includes(index)) {
+         onChange?.(values.filter(dia => dia !== index))
+      } else {
+         onChange?.([...values, index])
+      }
+   }
+   // Todo: bug distancia maior que 16px (gap)
+   return (
+      <div className="flex  bg-lightpurple rounded-4xl justify-around p-1  max-w-150">
+         {days.map((day, index) =>
+            <button key={index} onClick={() => handleToggle(index)} disabled={isReadOnly}
+               className={`bg-offwhite  max-w-10.5  h-10.5 flex-1 rounded-full list-none flex items-center justify-center
+       drop-shadow-lg font-merriweather text-2xl
+                   ${values.includes(index) ? 'border-darkpurple border-3' : ''}
+       `}
+            >
+               {day}
+            </button>)
+         }
+      </div>
+   );
+}


### PR DESCRIPTION
…closes #46
## What was implemented

- New `WeekDaySelector` component for weekday selection
- Support for edit mode (day toggle) and read-only mode (`isReadOnly`)
- Multiple selection with visual highlight (purple border) on selected days
- Responsive with `flex-1` and `max-w` to maintain circular shape
- Interaction blocked via `disabled` and `select-none` in read-only mode

## How to test

- Navigate to `AddMedication` screen
- Click on day circles — they should toggle between selected/unselected
- Selected day displays purple border
- Check on different screen sizes

## Known issues

- Gap between circles may exceed 16px on larger screens (TODO in code)
- `isReadOnly` mode has no visual difference yet