### PR TITLE
add information box component Closes #71

### DIFF
--- a/src/view/components/common/InfoTile.tsx
+++ b/src/view/components/common/InfoTile.tsx
@@ -1,0 +1,34 @@
+
+
+interface InfoTileProps {
+   title: string;
+   value: string;
+   accentColor?: string;
+}
+
+export function InfoTile({ title, value, accentColor }: InfoTileProps) {
+
+   return (
+      <div className="w-[170px] h-[84px] bg-offwhite rounded-[10px] border-b-4 flex justify-between font-merriweather border-darkpurple px-3 ">
+
+         <div className="py-3">
+            <h1 className="text-[#6d6d6d] text-[20px]">
+               {title}
+            </h1>
+            <p className="text-inkblack text-[20px]">
+               {value}
+            </p>
+         </div>
+         {accentColor && 
+         <div 
+         // bg-[${accentColor}] not works in runtime
+         className={`h-full w-5 `}
+         
+         style={{ backgroundColor: accentColor }}
+> 
+         
+         </div>}
+      </div>
+   )
+
+}


### PR DESCRIPTION
Add a Tile Card info component, like the design made by Karyn.
To use it, we need to create an `<InfoTile /> `component
with the parameters `title` and `value` (description).
You can add a right bar color to match the brand color by adding `accentColor="color"` with any hex color.
